### PR TITLE
úprava dlouhého označení Strana Zelených na Zelení (žádost KKu)

### DIFF
--- a/_candidatelists/magistrat.md
+++ b/_candidatelists/magistrat.md
@@ -13,7 +13,7 @@ head: # čelo kandidátky (bez leadera) / lidé kteří mají fotku a _people/jm
   - uid: jakub.kutilek
     profession: dopravní specialista
     description: člen spolku Město na kole, Strany zelených a Iniciativy Přírodní park Červeňák
-    party: Strana Zelených
+    party: Zelení
   - uid: ivana.bohmova
     profession: pedagožka
     party: Piráti


### PR DESCRIPTION
Zelení jsou podobně oficiální označení jako Piráti.